### PR TITLE
fix clippy warnings

### DIFF
--- a/src/about.rs
+++ b/src/about.rs
@@ -22,9 +22,8 @@ pub fn open(term: &mut Terminal) {
 
     'main: loop {
         while let Some(Event::Key(ch)) = term.get_event(0).unwrap() {
-            match ui.result_for_key(ch) {
-                Some(ButtonResult::Ok) => break 'main,
-                _                      => {}
+            if let Some(ButtonResult::Ok) = ui.result_for_key(ch) { 
+                break 'main
             }
         }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -117,7 +117,7 @@ impl Game {
             if play {
                 let mut alive = 0;
                 let (cols, rows) = self.grid.playable_size();
-                let ref ruleset = self.ruleset;
+                let ruleset = &self.ruleset;
 
                 // Iterate over the playable region
                 for y in 1..rows {

--- a/src/input.rs
+++ b/src/input.rs
@@ -25,7 +25,7 @@ pub fn integer_prompt(term: &mut Terminal) -> Option<u32> {
     // TO-DO: Fix this abomination, this code segment is HORRIBLE due to a bug
     // discovered in the rustty fork. I honestly have no idea how to fix the bug 
     // too, RIP. That's why you see the '_' placed before and after, it's a workaround
-    let mut value = "_".to_string();
+    let mut value = "_".to_owned();
     let mut input = Label::new(15,1);
     input.pack(&prompt, HorizontalAlign::Middle, VerticalAlign::Middle, (0,0));
     'main: loop {

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -88,7 +88,7 @@ fn create_ui(width: usize, height: usize, presets: &mut Vec<String>)
             btn.pack(&dlg, HorizontalAlign::Left, VerticalAlign::Top,
                      (2,i as usize));
             dlg.add_button(btn);
-            presets.push(path.to_str().unwrap().to_string());
+            presets.push(path.to_str().unwrap().to_owned());
             i += 1;
         }
     }

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -19,7 +19,7 @@ impl Ruleset {
                   speed: rules.5, }
     }
 
-    pub fn update(&mut self, nrules: &Vec<i32>) {
+    pub fn update(&mut self, nrules: &[i32]) {
         if nrules[0] != -1 { self.starvation = nrules[0] as u8 }
         else if nrules[1] != -1 { self.living = nrules[1] as u8}
         else if nrules[2] != -1 { self.smothered = nrules[2] as u8 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-use ruleset::Ruleset;
+    use ruleset::Ruleset;
 
 use rustty::{
     Terminal, 
@@ -50,7 +50,7 @@ pub fn open(_ruleset: &mut Ruleset, term: &mut Terminal) {
                             if res <= 8 {
                                 new_rules[(i-1) as usize] = res as i32;
                             } else {
-                                errors = "Invalid value(0-8)".to_string();
+                                errors = "Invalid value(0-8)".to_owned();
                             }
                         } else if i == 5 {
                             // options > 5 are rules for randomization, thus cannot exceed
@@ -58,7 +58,7 @@ pub fn open(_ruleset: &mut Ruleset, term: &mut Terminal) {
                             if res <= 100 {
                                 new_rules[(i-1) as usize] = res as i32;
                             } else {
-                                errors = "Invalid value(0-100)".to_string();
+                                errors = "Invalid value(0-100)".to_owned();
                             }
                         } else {
                             new_rules[(i-1) as usize] = res as i32;
@@ -91,14 +91,14 @@ fn create_ui(width: usize, height: usize,rules: &Ruleset) -> Dialog {
 
     let mut category1 = Label::new(width-3, 3);
     category1.align_text(HorizontalAlign::Left, VerticalAlign::Top, (0,0));
-    category1.set_text("Generational Rules: ".to_string() 
+    category1.set_text("Generational Rules: ".to_owned() 
                        + &(0..width-4).map(|_| "─").collect::<String>());
     category1.pack(&dlg, HorizontalAlign::Left, VerticalAlign::Top, (2, 3));
     dlg.add_label(category1);
 
     let mut category2 = Label::new(width-3, 3);
     category2.align_text(HorizontalAlign::Left, VerticalAlign::Top, (0,0));
-    category2.set_text("Randomize ".to_string()
+    category2.set_text("Randomize ".to_owned()
                        + &(0..width-4).map(|_| "─").collect::<String>());
     category2.pack(&dlg, HorizontalAlign::Left, VerticalAlign::Top, 
                    (2, CATEGORY1_S+5));
@@ -106,7 +106,7 @@ fn create_ui(width: usize, height: usize,rules: &Ruleset) -> Dialog {
 
     let mut category3 = Label::new(width-3, 3);
     category3.align_text(HorizontalAlign::Left, VerticalAlign::Top, (0,0));
-    category3.set_text("Game Speed ".to_string()
+    category3.set_text("Game Speed ".to_owned()
                        + &(0..width-4).map(|_| "─").collect::<String>());
     category3.pack(&dlg, HorizontalAlign::Left, VerticalAlign::Top, 
                    (2, CATEGORY2_S+3));


### PR DESCRIPTION
Just fixed a few clippy warnings. I note that you appear to use `String`s often where `'static str`s would do. Changing this may reduce memory usage and improve performance. Apart from that small nitpick, nice project.
